### PR TITLE
Ngt-Popover como Diretiva

### DIFF
--- a/projects/ng-tailwind/src/components/ngt-popover/ngt-popover-tooltip/ngt-popover-tooltip.component.html
+++ b/projects/ng-tailwind/src/components/ngt-popover/ngt-popover-tooltip/ngt-popover-tooltip.component.html
@@ -1,0 +1,10 @@
+<div class="bg-white rounded-lg shadow-lg absolute" [ngClass]="positionClasses[position]"
+    style="z-index: 999999 !important;" (click)="$event.stopPropagation()" @enterAnimation>
+    <div *ngIf="!popoverTemplate; else showTemplate" class="px-2 py-1">
+        {{ popover }}
+    </div>
+
+    <ng-template #showTemplate>
+        <ng-container [ngTemplateOutlet]="popoverTemplate"></ng-container>
+    </ng-template>
+</div>

--- a/projects/ng-tailwind/src/components/ngt-popover/ngt-popover-tooltip/ngt-popover-tooltip.component.ts
+++ b/projects/ng-tailwind/src/components/ngt-popover/ngt-popover-tooltip/ngt-popover-tooltip.component.ts
@@ -1,0 +1,31 @@
+import { animate, state, style, transition, trigger } from '@angular/animations';
+import { Component, TemplateRef } from '@angular/core';
+
+@Component({
+    selector: 'ngt-popover-tooltip',
+    templateUrl: './ngt-popover-tooltip.component.html',
+    animations: [
+        trigger('enterAnimation', [
+            state('void', style({ transform: 'translateY(-20px)', opacity: 0 })),
+            transition(':enter', [
+                animate(200)
+            ])
+        ]),
+    ]
+})
+export class NgtPopoverTooltipComponent{
+    public popover: string;
+    public popoverTemplate: TemplateRef<any>;
+    public position: NgtPopoverPosition = NgtPopoverPosition.DEFAULT;
+
+    public positionClasses: any = {
+        [NgtPopoverPosition.TOP]: 'top-0 -mt-10',
+        [NgtPopoverPosition.BOTTOM]: 'bottom-0 -mb-10',
+    };
+}
+
+export enum NgtPopoverPosition {
+    DEFAULT = 'TOP',
+    TOP = 'TOP',
+    BOTTOM = 'BOTTOM',
+}

--- a/projects/ng-tailwind/src/components/ngt-popover/ngt-popover.directive.ts
+++ b/projects/ng-tailwind/src/components/ngt-popover/ngt-popover.directive.ts
@@ -1,0 +1,118 @@
+import {
+    ComponentFactoryResolver,
+    ComponentRef,
+    Directive,
+    ElementRef,
+    HostListener,
+    Input,
+    OnDestroy,
+    TemplateRef,
+    ViewContainerRef,
+} from '@angular/core';
+
+import { NgtPopoverPosition, NgtPopoverTooltipComponent } from './ngt-popover-tooltip/ngt-popover-tooltip.component';
+import { NgtPopoverOpenMethod } from './ngt-popover.component';
+
+@Directive({
+    selector: '[ngt-popover]'
+})
+export class NgtPopoverDirective implements OnDestroy {
+    @Input() public popover: string;
+    @Input() public popoverTemplate: TemplateRef<any>;
+
+    @Input() public dismissDelay: number = 150;
+    @Input() public dismissOnClick: boolean;
+    @Input() public position: NgtPopoverPosition = NgtPopoverPosition.DEFAULT;
+    @Input() public openMethod: 'HOVER' | 'CLICK' = NgtPopoverOpenMethod.HOVER;
+
+    private componentRef: ComponentRef<NgtPopoverTooltipComponent> = null;
+    private dismissTimeoutInstance: NodeJS.Timeout;
+
+    public constructor(
+        private elementRef: ElementRef,
+        private componentFactoryResolver: ComponentFactoryResolver,
+        private viewContainerRef: ViewContainerRef
+    ) { }
+
+    @HostListener('click')
+    public onClick(): void {
+        if (this.openMethod != NgtPopoverOpenMethod.CLICK) {
+            return;
+        }
+
+        if (!this.componentRef) {
+            this.createPopover();
+
+            return;
+        }
+
+        this.destroy();
+    }
+
+    @HostListener('document:click', ['$event.target'])
+    public onDocumentClick(target: HTMLElement) {
+        if (
+            this.dismissOnClick
+            && !this.componentRef?.location?.nativeElement?.contains(target)
+            && target !== this.elementRef.nativeElement
+            && target !== this.componentRef?.location?.nativeElement
+        ) {
+            this.destroy();
+        }
+    }
+
+    @HostListener('mouseleave')
+    public onMouseLeave(): void {
+        if (this.dismissOnClick) {
+            return;
+        }
+
+        if (this.dismissTimeoutInstance) {
+            clearTimeout(this.dismissTimeoutInstance);
+        }
+
+        this.dismissTimeoutInstance = setTimeout(() => this.destroy(), this.dismissDelay);
+    }
+
+    @HostListener('mouseenter')
+    public onMouseEnter(): void {
+        if (this.componentRef || this.openMethod != NgtPopoverOpenMethod.HOVER) {
+            return;
+        }
+
+        this.createPopover();
+    }
+
+    public ngOnDestroy(): void {
+        this.destroy();
+    }
+
+    private createPopover(): void {
+        const componentFactory = this.componentFactoryResolver.resolveComponentFactory(NgtPopoverTooltipComponent);
+
+        this.componentRef = this.viewContainerRef.createComponent(componentFactory);
+
+        this.setupPopoverComponent();
+    }
+
+    private destroy(): void {
+        this.componentRef?.destroy();
+        this.componentRef = null;
+    }
+
+    private setupPopoverComponent(): void {
+        if (!this.componentRef) {
+            return;
+        }
+
+        this.componentRef.instance.popover = this.popover;
+        this.componentRef.instance.popoverTemplate = this.popoverTemplate;
+        this.componentRef.instance.position = this.position;
+
+        const hostElement = this.elementRef.nativeElement;
+        const popoverElement = this.componentRef.location.nativeElement;
+
+        hostElement.classList.add('relative');
+        hostElement.appendChild(popoverElement);
+    }
+}

--- a/projects/ng-tailwind/src/components/ngt-popover/ngt-popover.module.ts
+++ b/projects/ng-tailwind/src/components/ngt-popover/ngt-popover.module.ts
@@ -2,11 +2,20 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
 import { NgtDropdownModule } from '../ngt-dropdown/ngt-dropdown.module';
+import { NgtPopoverTooltipComponent } from './ngt-popover-tooltip/ngt-popover-tooltip.component';
 import { NgtPopoverComponent } from './ngt-popover.component';
+import { NgtPopoverDirective } from './ngt-popover.directive';
 
 @NgModule({
-    declarations: [ NgtPopoverComponent ],
-    exports: [ NgtPopoverComponent ],
+    exports: [
+        NgtPopoverComponent,
+        NgtPopoverDirective
+    ],
+    declarations: [
+        NgtPopoverComponent,
+        NgtPopoverTooltipComponent,
+        NgtPopoverDirective
+    ],
     imports: [
         CommonModule,
         NgtDropdownModule

--- a/projects/ng-tailwind/src/public-api.ts
+++ b/projects/ng-tailwind/src/public-api.ts
@@ -151,3 +151,4 @@ export * from './components/ngt-helper/ngt-helper.component';
 // NgtPopover
 export * from './components/ngt-popover/ngt-popover.module';
 export * from './components/ngt-popover/ngt-popover.component';
+export * from './components/ngt-popover/ngt-popover.directive';


### PR DESCRIPTION
Esta PR adiciona um funcionamento do Ngt-popver como diretiva, com comportametnos básicos para funcionamento em hover e click.
![image](https://github.com/EloverdeTech/ng-tailwind/assets/40645592/48511713-b665-4a0e-964b-feb58adb400a)
