### PR TITLE
Menu de Contexto

### DIFF
--- a/projects/ng-tailwind/src/components/ngt-context-menu/ngt-context-menu.component.html
+++ b/projects/ng-tailwind/src/components/ngt-context-menu/ngt-context-menu.component.html
@@ -1,0 +1,24 @@
+<div class="absolute max-w-7xl -mr-10 -mb-10" style="z-index: 999999 !important; width: max-content !important;"
+    [style.left.px]="positionX" [style.top.px]="positionY" (click)="$event.stopPropagation()">
+
+    <ng-container *ngIf="hasOptions(); else showTemplate">
+        <ul class="cursor-pointer rounded-xl bg-white border border-gray-200 shadow-2xl ">
+            <li *ngFor="let item of menuItems; last as isLast; first as isFirst" class="flex"
+                class="flex items-center w-full px-4 py-2 gap-3 text-sm text-gray-700 hover:text-white"
+                [class.rounded-b-xl]="isLast" [class.rounded-t-xl]="isFirst"
+                [ngClass]="item.background_color || 'hover:bg-green-500'" (click)="onMenuItemClick.emit(item)">
+
+                <ngt-svg *ngIf="item.icon" class="text-lg" [src]="item.icon"></ngt-svg>
+
+                {{ item.caption }}
+            </li>
+        </ul>
+    </ng-container>
+
+    <ng-template #showTemplate>
+        <div class="block rounded-lg bg-white border border-gray-200 w-full h-auto shadow-2xl"
+            (click)="onTemplateClick.emit()">
+            <ng-container [ngTemplateOutlet]="menuTemplate"></ng-container>
+        </div>
+    </ng-template>
+</div>

--- a/projects/ng-tailwind/src/components/ngt-context-menu/ngt-context-menu.component.ts
+++ b/projects/ng-tailwind/src/components/ngt-context-menu/ngt-context-menu.component.ts
@@ -1,0 +1,28 @@
+import { Component, EventEmitter, Output, TemplateRef } from '@angular/core';
+
+@Component({
+    selector: 'ngt-context-menu',
+    templateUrl: './ngt-context-menu.component.html'
+})
+
+export class NgtContextMenuComponent {
+    @Output() public onMenuItemClick: EventEmitter<NgtContextMenuOptionInterface> = new EventEmitter();
+    @Output() public onTemplateClick: EventEmitter<void> = new EventEmitter();
+
+    public positionX: number;
+    public positionY: number;
+
+    public menuTemplate: TemplateRef<any>;
+    public menuItems: NgtContextMenuOptionInterface[] = [];
+
+    public hasOptions(): boolean {
+        return !this.menuTemplate && !!this.menuItems?.length;
+    }
+}
+
+export interface NgtContextMenuOptionInterface {
+    caption: string;
+    background_color?: string;
+    icon?: string;
+    value: string;
+}

--- a/projects/ng-tailwind/src/components/ngt-context-menu/ngt-context-menu.directive.ts
+++ b/projects/ng-tailwind/src/components/ngt-context-menu/ngt-context-menu.directive.ts
@@ -1,0 +1,87 @@
+import {
+    ComponentRef,
+    Directive,
+    EventEmitter,
+    HostListener,
+    Input,
+    OnDestroy,
+    Output,
+    TemplateRef,
+    ViewContainerRef,
+} from '@angular/core';
+import { Subscription } from 'rxjs';
+
+import { NgtContextMenuComponent, NgtContextMenuOptionInterface } from './ngt-context-menu.component';
+
+@Directive({
+    selector: '[ngt-contextmenu]'
+})
+export class NgtContextMenuDirective implements OnDestroy {
+    @Output() public onNgtContextMenuClick: EventEmitter<NgtContextMenuOptionInterface> = new EventEmitter();
+
+    @Input() public ngtContextMenuOptions: NgtContextMenuOptionInterface[];
+    @Input() public ngtContextMenuTemplate: TemplateRef<any>;
+
+    private componentRef: ComponentRef<NgtContextMenuComponent> = null;
+    private menuItemClickSubscription: Subscription;
+    private templateClickSubscription: Subscription;
+
+    public constructor(private viewContainerRef: ViewContainerRef) { }
+
+    @HostListener('contextmenu', ['$event'])
+    public onContextMenu(event: MouseEvent) {
+        event.preventDefault();
+
+        this.destroy();
+        this.createComponent(event);
+    }
+
+    @HostListener('document:click')
+    public onDocumentClick() {
+        this.destroy();
+    }
+
+    @HostListener('click')
+    public onClick() {
+        this.destroy();
+    }
+
+    public ngOnDestroy(): void {
+        this.destroy();
+    }
+
+    private createComponent(event: MouseEvent): void {
+        this.componentRef = this.viewContainerRef.createComponent(NgtContextMenuComponent);
+
+        this.componentRef.instance.positionX = event.clientX;
+        this.componentRef.instance.positionY = event.clientY;
+        this.componentRef.instance.menuItems = this.ngtContextMenuOptions;
+        this.componentRef.instance.menuTemplate = this.ngtContextMenuTemplate;
+
+        this.bindSubscriptions();
+
+        document.body.appendChild(this.componentRef.location.nativeElement);
+    }
+
+    private bindSubscriptions(): void {
+        this.menuItemClickSubscription = this.componentRef.instance
+            .onMenuItemClick
+            .subscribe((event) => {
+                this.onNgtContextMenuClick.emit(event);
+
+                this.destroy();
+            });
+
+        this.templateClickSubscription = this.componentRef.instance
+            .onTemplateClick
+            .subscribe((event) => this.destroy());
+    }
+
+    private destroy(): void {
+        this.menuItemClickSubscription?.unsubscribe();
+        this.templateClickSubscription?.unsubscribe();
+        this.componentRef?.destroy();
+
+        this.componentRef = null;
+    }
+}

--- a/projects/ng-tailwind/src/components/ngt-context-menu/ngt-context-menu.module.ts
+++ b/projects/ng-tailwind/src/components/ngt-context-menu/ngt-context-menu.module.ts
@@ -1,0 +1,22 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { NgtSvgModule } from '../ngt-svg/ngt-svg.module';
+import { NgtContextMenuComponent } from './ngt-context-menu.component';
+import { NgtContextMenuDirective } from './ngt-context-menu.directive';
+
+@NgModule({
+    declarations: [
+        NgtContextMenuDirective,
+        NgtContextMenuComponent,
+    ],
+    exports: [
+        NgtContextMenuDirective,
+        NgtContextMenuComponent,
+    ],
+    imports: [
+        CommonModule,
+        NgtSvgModule
+    ],
+})
+export class NgtContextMenuModule { }

--- a/projects/ng-tailwind/src/components/ngt-popover/ngt-popover-tooltip/ngt-popover-tooltip.component.html
+++ b/projects/ng-tailwind/src/components/ngt-popover/ngt-popover-tooltip/ngt-popover-tooltip.component.html
@@ -1,8 +1,9 @@
-<div class="bg-white rounded-lg shadow-xl border border-gray-100 absolute max-w-7xl"
-    [ngClass]="positionClasses[position]" style="z-index: 999999 !important; width: max-content !important;"
+<div class="bg-white rounded-lg shadow-2xl border border-gray-200 absolute max-w-7xl"
+    [ngClass]="positionClasses[position]" [style.left.px]="positionX" [style.top.px]="positionY"
+    style="z-index: 999999 !important; width: max-content !important;"
     (click)="$event.stopPropagation()" @enterAnimation>
 
-    <div *ngIf="!popoverTemplate; else showTemplate" class="px-2 py-1 text-gray-500 whitespace-nowrap">
+    <div *ngIf="!popoverTemplate; else showTemplate" class="px-2 py-1 text-gray-700 whitespace-nowrap">
         {{ popover }}
     </div>
 

--- a/projects/ng-tailwind/src/components/ngt-popover/ngt-popover-tooltip/ngt-popover-tooltip.component.ts
+++ b/projects/ng-tailwind/src/components/ngt-popover/ngt-popover-tooltip/ngt-popover-tooltip.component.ts
@@ -17,10 +17,12 @@ export class NgtPopoverTooltipComponent{
     public popover: string;
     public popoverTemplate: TemplateRef<any>;
     public position: NgtPopoverPosition = NgtPopoverPosition.DEFAULT;
+    public positionX: number;
+    public positionY: number;
 
     public positionClasses: any = {
-        [NgtPopoverPosition.TOP]: 'top-0 -mt-10',
-        [NgtPopoverPosition.BOTTOM]: 'bottom-0 -mb-10',
+        [NgtPopoverPosition.TOP]: '-mt-10',
+        [NgtPopoverPosition.BOTTOM]: '-mb-10',
     };
 }
 

--- a/projects/ng-tailwind/src/public-api.ts
+++ b/projects/ng-tailwind/src/public-api.ts
@@ -152,3 +152,8 @@ export * from './components/ngt-helper/ngt-helper.component';
 export * from './components/ngt-popover/ngt-popover.module';
 export * from './components/ngt-popover/ngt-popover.component';
 export * from './components/ngt-popover/ngt-popover.directive';
+
+// NgtContextMenu
+export * from './components/ngt-context-menu/ngt-context-menu.module';
+export * from './components/ngt-context-menu/ngt-context-menu.component';
+export * from './components/ngt-context-menu/ngt-context-menu.directive';


### PR DESCRIPTION
Criado NgtContextMenu para facilitar a criação de menus de contextos de forma menos verbosa:
- o menu é aberto proximo ao local do click;
- permite utilizar um array de objetos ou um template;
![image](https://github.com/EloverdeTech/ng-tailwind/assets/40645592/c77f4b0a-566a-4e26-a09d-95086e318a28)
![image](https://github.com/EloverdeTech/ng-tailwind/assets/40645592/acfc7114-4d88-43ea-a96b-c2af40668d82)

Também foram adicionadas melhorias ao NgtPopover via diretiva:
- adicionado um showDelay, assim o popover só aparece apos o cursor estiver parado por um tempo no elemento;
- agora o popover é construido de forma absoluta na pagina (document), assim classes como `overflow` e `truncate` não impactam seu uso (escapa do scroll). 
![image](https://github.com/EloverdeTech/ng-tailwind/assets/40645592/dc260007-17b7-47a3-8cd8-f26b1085ef83)
