### PR TITLE
Publicar versão 4.2.21

### DIFF
--- a/projects/ng-tailwind/package.json
+++ b/projects/ng-tailwind/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ng-tailwind",
-    "version": "4.2.20",
+    "version": "4.2.21",
     "peerDependencies": {
         "@angular/common": "<16.0.0",
         "@angular/core": "<16.0.0",

--- a/projects/ng-tailwind/src/components/ngt-context-menu/ngt-context-menu.directive.ts
+++ b/projects/ng-tailwind/src/components/ngt-context-menu/ngt-context-menu.directive.ts
@@ -1,4 +1,5 @@
 import {
+    ChangeDetectorRef,
     ComponentRef,
     Directive,
     EventEmitter,
@@ -26,14 +27,27 @@ export class NgtContextMenuDirective implements OnDestroy {
     private menuItemClickSubscription: Subscription;
     private templateClickSubscription: Subscription;
 
-    public constructor(private viewContainerRef: ViewContainerRef) { }
+    public constructor(
+        private viewContainerRef: ViewContainerRef,
+        private changeDetector: ChangeDetectorRef,
+    ) { }
 
     @HostListener('contextmenu', ['$event'])
     public onContextMenu(event: MouseEvent) {
         event.preventDefault();
 
+        setTimeout(() => {
+            this.destroy();
+            this.createComponent(event);
+        }, 50);
+    }
+
+    @HostListener('document:contextmenu', ['$event'])
+    public onDocumentContextMenuClick(event: MouseEvent) {
+        event.preventDefault();
+
         this.destroy();
-        this.createComponent(event);
+        this.changeDetector.detectChanges();
     }
 
     @HostListener('document:click')

--- a/projects/ng-tailwind/src/components/ngt-select/ngt-select.component.ts
+++ b/projects/ng-tailwind/src/components/ngt-select/ngt-select.component.ts
@@ -96,6 +96,7 @@ export class NgtSelectComponent extends NgtBaseNgModel implements OnChanges, OnD
     @Input() public tabIndex: number;
     @Input() public typeahead: Subject<any>;
     @Input() public guessCompareWith: boolean = true;
+    @Input() public autoSelectUniqueOption: boolean = false;
     @Input() public groupValue: (groupKey: string, cildren: any[]) => Object;
     @Input() public trackBy: (item: any) => any;
 
@@ -330,6 +331,10 @@ export class NgtSelectComponent extends NgtBaseNgModel implements OnChanges, OnD
                             this.bindCompareWithByResponse(response);
 
                             this.ngSearchObserver.next(response.data);
+
+                            if (this.canAutoSelectUniqueOption(response)) {
+                                this.onNativeChange(response.data[0]);
+                            }
 
                             this.onLoadRemoteResource.emit(response.data);
 
@@ -566,6 +571,13 @@ export class NgtSelectComponent extends NgtBaseNgModel implements OnChanges, OnD
     private destroySubscriptions() {
         this.subscriptions.forEach(subscription => subscription.unsubscribe());
         this.subscriptions = [];
+    }
+
+    private canAutoSelectUniqueOption(response: NgtHttpResponse): boolean {
+        return !this.value
+            && this.autoSelectUniqueOption
+            && Array.isArray(response.data)
+            && response.data?.length === 1;
     }
 }
 


### PR DESCRIPTION
- destroi o ngt-contextmenu ao abrir um novo
- adiciona opção de selecionar automaticamente quando o ngt-select tem apenas um resource disponível.